### PR TITLE
Update typescript-webpack-react hooks & load default CSS

### DIFF
--- a/Templates/TypeScriptWebpackReactVisualizationTemplate/helpers/hooks/useOutput.tsx
+++ b/Templates/TypeScriptWebpackReactVisualizationTemplate/helpers/hooks/useOutput.tsx
@@ -1,6 +1,11 @@
-import { getVisualizationOutputs } from "@helpers/config";
-import { ConfigContext } from "@helpers/context/configContext";
 import { useContext, useEffect, useState } from "react";
+import { ConfigContext } from "@helpers/context/configContext";
+import { getVisualizationOutputs } from "@helpers/config";
+
+// The following import may fail if a user has not
+//  built the custom visualization at least once so we ignore it
+//@ts-ignore
+import visualizationConfig from "@core/visualization.config.json";
 
 export const updateOutputEventKey = "mood-update-output";
 export type updateOutputEvent = CustomEvent<{
@@ -21,7 +26,9 @@ export function useOutput<TOutput extends keyof Vis.Outputs>(
   output: TOutput
 ): [
   setOutput: (value: MooDOutputRawType<Vis.Outputs, TOutput>) => void,
-  value?: Readonly<MooDOutputRawType<Vis.Outputs, TOutput>> | undefined
+  value: Vis.Outputs[TOutput] extends SinglePickList | MultiPickList | Elements
+    ? Readonly<string[]>
+    : undefined | Readonly<Vis.Outputs[TOutput]>
 ] {
   const config = useContext(ConfigContext);
   const [value, setValue] = useState<Vis.Outputs[TOutput] | undefined>(
@@ -39,10 +46,40 @@ export function useOutput<TOutput extends keyof Vis.Outputs>(
     };
   }, [config]);
 
-  return [
-    (value: MooDOutputRawType<Vis.Outputs, TOutput>) => {
-      config.functions.updateOutput(output, value);
-    },
-    value as Readonly<MooDOutputRawType<Vis.Outputs, TOutput>> | undefined,
-  ];
+  function updateOutput(value: MooDOutputRawType<Vis.Outputs, TOutput>) {
+    config.functions.updateOutput(output, value);
+  }
+
+  const outputConfigType =
+    visualizationConfig.outputs.length == 0
+      ? ""
+      : (
+          visualizationConfig.outputs as {
+            name: keyof Vis.Outputs;
+            type: string;
+          }[]
+        )
+          .find((outputConfig) => outputConfig.name == output)
+          ?.type.toLowerCase() ?? "";
+
+  // If the input type is one of a potential array then we convert it to always be an array
+  if (
+    outputConfigType === "colour" ||
+    outputConfigType === "color" ||
+    outputConfigType === "shape" ||
+    outputConfigType === "elements"
+  ) {
+    // elements can be provided as an array by default so we don't need to convert it
+    if (Array.isArray(value)) return [updateOutput, value as any];
+    return [
+      updateOutput,
+      Object.freeze(
+        ((value as string) ?? "")
+          .split(",")
+          .filter((val: string) => val != "") as any
+      ),
+    ];
+  }
+
+  return [updateOutput, value as any];
 }

--- a/Templates/TypeScriptWebpackReactVisualizationTemplate/src/visualization01/no-guid.visualization.config.json.ejs
+++ b/Templates/TypeScriptWebpackReactVisualizationTemplate/src/visualization01/no-guid.visualization.config.json.ejs
@@ -42,6 +42,7 @@
       }
     ],
     "style": {
+        "URL": "visualization01/visualization.css",
         "JSON": {
             "DevelopmentMode": false
         }


### PR DESCRIPTION
Fixed bug with useInput that always returned the raw result of the value not converted to an array

Updated useInput to allow undefined when the type isn't converted to an array

useOutput now has similar functionality to useInput where it will automatically convert the previous results to an array if it is one of a few specific types

Load visulization css by default