### PR TITLE
Change ECharts tree chart default label orientation

### DIFF
--- a/Examples/EChartsRadialTree/README.md
+++ b/Examples/EChartsRadialTree/README.md
@@ -69,7 +69,7 @@ The properties mirror the properties in the __options__ object used to configure
   * __label__: Describes the style of the text corresponding to each node.
     * __show__: Defines if the labels are to be shown (true) or not (false). __Default true__
     * __fontSize__: The size of the font for the label. __Default 12__
-    * __rotate__: The angle in degrees to rotate the label text. __Default 0__
+    * __rotate__: The angle in degrees to rotate all label text from the horizontal. If null or undefined the text is aligned with the lines coming in to the node. __Default null__
   * __leafLabel__: Describes the style of the text corresponding to the leaf nodes.
     * __show__: Defines if the labels are to be shown (true) or not (false) on leaf nodes. __Default true__
     * __fontSize__: The size of the font for the label on leaf nodes. __Default 12__

--- a/Examples/EChartsRadialTree/package-lock.json
+++ b/Examples/EChartsRadialTree/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "echarts-radial-chart",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "echarts-radial-chart",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "license": "MIT",
       "dependencies": {
         "core-js": "3.19.0",

--- a/Examples/EChartsRadialTree/package.json
+++ b/Examples/EChartsRadialTree/package.json
@@ -1,7 +1,7 @@
 {
   "name": "echarts-radial-chart",
   "description": "ECharts Radial Tree Visualization",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "license": "MIT",
   "dependencies": {
     "core-js": "3.19.0",

--- a/Examples/EChartsRadialTree/src/visualization01/visualization.config.json.ejs
+++ b/Examples/EChartsRadialTree/src/visualization01/visualization.config.json.ejs
@@ -40,7 +40,7 @@
       "label": {
         "show": true,
         "fontSize": 12,
-        "rotate": 0
+        "rotate": null
       },
       "leafLabel": {
         "show": true,

--- a/Examples/EChartsRadialTree/src/visualization01/visualization.js
+++ b/Examples/EChartsRadialTree/src/visualization01/visualization.js
@@ -68,10 +68,10 @@ export function visualization (config) {
           : 12)
       : 12
     const labelRotation = style.series.label
-      ? (style.series.label.rotate !== undefined
+      ? (style.series.label.rotate !== undefined && style.series.label.rotate !== null
           ? style.series.label.rotate
-          : 0)
-      : 0
+          : undefined)
+      : undefined
     const showLeafLabel = style.series.leafLabel
       ? (style.series.leafLabel.show !== undefined
           ? style.series.leafLabel.show

--- a/Examples/EChartsRadialTree/test/visualization01/style.json
+++ b/Examples/EChartsRadialTree/test/visualization01/style.json
@@ -4,7 +4,7 @@
         "series": {
             "top": "18%",
             "bottom": "14%",
-            "layout": "orthogonal",
+            "layout": "radial",
             "orient": "LR",
             "showTooltip": true,
             "symbol": "emptyCircle",
@@ -15,10 +15,10 @@
             "label": {
                 "show": true,
                 "fontSize": 12,
-                "rotate": 45
+                "rotate": null
             },
             "leafLabel": {
-                "show": false,
+                "show": true,
                 "fontSize": 8
               },
             "emphasis": {


### PR DESCRIPTION
Change default orientation of label text in EChart tree chart to align with the line coming into the node