### PR TITLE
Update jointjs

### DIFF
--- a/Examples/ProcessFlow/package-lock.json
+++ b/Examples/ProcessFlow/package-lock.json
@@ -1,18 +1,17 @@
 {
   "name": "process-flow",
-  "version": "2.6.6",
+  "version": "2.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "process-flow",
-      "version": "2.6.6",
+      "version": "2.7.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "core-js": "3.22.0",
-        "jointjs": "3.4.4",
-        "jquery": "3.6.0"
+        "@joint/core": "^4.1.3",
+        "core-js": "3.22.0"
       },
       "devDependencies": {
         "@babel/core": "^7.22.9",
@@ -2603,6 +2602,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/@joint/core": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@joint/core/-/core-4.1.3.tgz",
+      "integrity": "sha512-X769blCoVxtx6NNm/cbHDXDOa+Gt7eZwrJMLnqJw8c5NkjmcYWCY1kA3ep8RfRRVG76f3QLNd9a8Q/aItI/WWw=="
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
@@ -3918,14 +3922,6 @@
         "@babel/core": "^7.0.0"
       }
     },
-    "node_modules/backbone": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.4.0.tgz",
-      "integrity": "sha512-RLmDrRXkVdouTg38jcgHhyQ/2zjg7a8E6sz2zxfz21Hh17xDJYUHBZimVIt5fUyS8vbfpeSmTL3gUjTEvUV3qQ==",
-      "dependencies": {
-        "underscore": ">=1.8.3"
-      }
-    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -4727,15 +4723,6 @@
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
       "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
       "dev": true
-    },
-    "node_modules/dagre": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/dagre/-/dagre-0.8.5.tgz",
-      "integrity": "sha512-/aTqmnRta7x7MCCpExk7HQL2O4owCT2h8NT//9I1OQ9vt29Pa0BzSAkR5lwFUcQ7491yVi/3CXU9jQ5o0Mn2Sw==",
-      "dependencies": {
-        "graphlib": "^2.1.8",
-        "lodash": "^4.17.15"
-      }
     },
     "node_modules/data-urls": {
       "version": "3.0.2",
@@ -6896,14 +6883,6 @@
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
-    },
-    "node_modules/graphlib": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/graphlib/-/graphlib-2.1.8.tgz",
-      "integrity": "sha512-jcLLfkpoVGmH7/InMC/1hIvOPSUh38oJtGhvrOFGzioE1DZ+0YW16RgmOJhHiuWTvGiJQ9Z1Ik43JvkRPRvE+A==",
-      "dependencies": {
-        "lodash": "^4.17.15"
-      }
     },
     "node_modules/handle-thing": {
       "version": "2.0.1",
@@ -9644,23 +9623,6 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
-    "node_modules/jointjs": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/jointjs/-/jointjs-3.4.4.tgz",
-      "integrity": "sha512-X4eBjO7P8Uxi06+V2hgvF1PCNWGbz6jSYPIbFgnJ4sSYL8dbgPWOA7+LNA8QXswTP9EIHsHhoh03HLiHqKkjWA==",
-      "dependencies": {
-        "backbone": "~1.4.0",
-        "dagre": "~0.8.5",
-        "graphlib": "~2.1.8",
-        "jquery": "~3.6.0",
-        "lodash": "~4.17.21"
-      }
-    },
-    "node_modules/jquery": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
-      "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw=="
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -9907,7 +9869,8 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
@@ -12331,7 +12294,8 @@
     "node_modules/underscore": {
       "version": "1.13.6",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
-      "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A=="
+      "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==",
+      "dev": true
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
@@ -15037,6 +15001,11 @@
         }
       }
     },
+    "@joint/core": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@joint/core/-/core-4.1.3.tgz",
+      "integrity": "sha512-X769blCoVxtx6NNm/cbHDXDOa+Gt7eZwrJMLnqJw8c5NkjmcYWCY1kA3ep8RfRRVG76f3QLNd9a8Q/aItI/WWw=="
+    },
     "@jridgewell/gen-mapping": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
@@ -16134,14 +16103,6 @@
         "babel-preset-current-node-syntax": "^1.0.0"
       }
     },
-    "backbone": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.4.0.tgz",
-      "integrity": "sha512-RLmDrRXkVdouTg38jcgHhyQ/2zjg7a8E6sz2zxfz21Hh17xDJYUHBZimVIt5fUyS8vbfpeSmTL3gUjTEvUV3qQ==",
-      "requires": {
-        "underscore": ">=1.8.3"
-      }
-    },
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -16744,15 +16705,6 @@
           "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
           "dev": true
         }
-      }
-    },
-    "dagre": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/dagre/-/dagre-0.8.5.tgz",
-      "integrity": "sha512-/aTqmnRta7x7MCCpExk7HQL2O4owCT2h8NT//9I1OQ9vt29Pa0BzSAkR5lwFUcQ7491yVi/3CXU9jQ5o0Mn2Sw==",
-      "requires": {
-        "graphlib": "^2.1.8",
-        "lodash": "^4.17.15"
       }
     },
     "data-urls": {
@@ -18313,14 +18265,6 @@
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
-    },
-    "graphlib": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/graphlib/-/graphlib-2.1.8.tgz",
-      "integrity": "sha512-jcLLfkpoVGmH7/InMC/1hIvOPSUh38oJtGhvrOFGzioE1DZ+0YW16RgmOJhHiuWTvGiJQ9Z1Ik43JvkRPRvE+A==",
-      "requires": {
-        "lodash": "^4.17.15"
-      }
     },
     "handle-thing": {
       "version": "2.0.1",
@@ -20310,23 +20254,6 @@
         }
       }
     },
-    "jointjs": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/jointjs/-/jointjs-3.4.4.tgz",
-      "integrity": "sha512-X4eBjO7P8Uxi06+V2hgvF1PCNWGbz6jSYPIbFgnJ4sSYL8dbgPWOA7+LNA8QXswTP9EIHsHhoh03HLiHqKkjWA==",
-      "requires": {
-        "backbone": "~1.4.0",
-        "dagre": "~0.8.5",
-        "graphlib": "~2.1.8",
-        "jquery": "~3.6.0",
-        "lodash": "~4.17.21"
-      }
-    },
-    "jquery": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
-      "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw=="
-    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -20519,7 +20446,8 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "lodash.debounce": {
       "version": "4.0.8",
@@ -22318,7 +22246,8 @@
     "underscore": {
       "version": "1.13.6",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
-      "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A=="
+      "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==",
+      "dev": true
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",

--- a/Examples/ProcessFlow/package.json
+++ b/Examples/ProcessFlow/package.json
@@ -1,12 +1,11 @@
 {
   "name": "process-flow",
   "description": "Visualisation of a Process Flow in swimlanes",
-  "version": "2.6.6",
+  "version": "2.7.0",
   "license": "MIT",
   "dependencies": {
-    "core-js": "3.22.0",
-    "jointjs": "3.4.4",
-    "jquery": "3.6.0"
+    "@joint/core": "^4.1.3",
+    "core-js": "3.22.0"
   },
   "devDependencies": {
     "@babel/core": "^7.22.9",

--- a/Examples/ProcessFlow/src/visualization01/jointjs-graph.js
+++ b/Examples/ProcessFlow/src/visualization01/jointjs-graph.js
@@ -1,5 +1,5 @@
 // See https://resources.jointjs.com/tutorial/elements
-import * as joint from 'jointjs'
+import * as joint from '@joint/core'
 import { mergeJumpover } from './jointjs-merge-jumpover'
 import { manhattanPlus } from './jointjs-manhattan-plus-router'
 import * as Shapes from './jointjs-shapes'
@@ -400,7 +400,9 @@ export class Graph {
       if (graphCells.length > 0) {
         const cell = graphCells[graphCells.length - 1]
         cell.toFront()
+        graphCells[0].toFront()
       }
+
       cells = []
       return drawingReport
     }
@@ -736,10 +738,7 @@ export class Graph {
           text: stepGroup.name(),
           textVerticalAnchor: labelConfig.textVerticalAnchor,
           textAnchor: labelConfig.textAnchor,
-          refX: labelConfig.refX,
-          refY: labelConfig.refY,
-          refX2: labelConfig.refX2,
-          refY2: labelConfig.refY2
+          transform: labelConfig.transform
         }
       })
       group.attr('label/text', stepGroup.name())
@@ -846,18 +845,18 @@ export class Graph {
          * @param {*} vertices
          * @param {*} args
          */
+
     joint.connectors.ioConnector = function (sourcePoint, targetPoint, vertices, args) {
       return joint.connectors.mergeJumpoverConnector.call(this, sourcePoint, targetPoint, vertices, args)
     }
-
     /**
      * Define a custom connector for that merges links that have the same target point.
      * The "merge" is achieved by not jumping over links with the same target point.
      * This is based on the jumpover connector
-     * @param {*} sourcePoint
-     * @param {*} targetPoint
-     * @param {*} vertices
-     * @param {*} args
+     * @param {g.Point} sourcePoint
+     * @param {g.Point} targetPoint
+     * @param {Array<g.Point>} vertices
+     * @param {object} args
      */
     joint.connectors.mergeJumpoverConnector = function (sourcePoint, targetPoint, vertices, args) {
       return mergeJumpover.call(this, sourcePoint, targetPoint, vertices, args)

--- a/Examples/ProcessFlow/src/visualization01/jointjs-group-label.js
+++ b/Examples/ProcessFlow/src/visualization01/jointjs-group-label.js
@@ -6,97 +6,61 @@ export const elementAttributes = {
   [ActivityGroup.labelPositionNW]: {
     textVerticalAnchor: 'top',
     textAnchor: 'start',
-    refX: '0%',
-    refY: '0%',
-    refX2: 5,
-    refY2: 5
+    transform: 'translate(5, 5)'
   },
   [ActivityGroup.labelPositionN]: {
     textVerticalAnchor: 'top',
     textAnchor: 'middle',
-    refX: '50%',
-    refY: '0%',
-    refX2: 0,
-    refY2: 5
+    transform: 'translate(calc(0.5*w), 5)'
   },
   [ActivityGroup.labelPositionNE]: {
     textVerticalAnchor: 'top',
     textAnchor: 'end',
-    refX: '100%',
-    refY: '0%',
-    refX2: -5,
-    refY2: 5
+    transform: 'translate(calc(w - 5), 5)'
   },
   [ActivityGroup.labelPositionW]: {
     textVerticalAnchor: 'middle',
     textAnchor: 'start',
-    refX: '0%',
-    refY: '50%',
-    refX2: 5,
-    refY2: 0
+    transform: 'translate(5, calc(0.5 * h))'
   },
   [ActivityGroup.labelPositionZero]: {
     textVerticalAnchor: 'middle',
     textAnchor: 'middle',
-    refX: '50%',
-    refY: '50%',
-    refX2: 0,
-    refY2: 0
+    transform: 'translate(calc(0.5 * w), calc(0.5 * h))'
   },
   [ActivityGroup.labelPositionE]: {
     textVerticalAnchor: 'middle',
     textAnchor: 'end',
-    refX: '100%',
-    refY: '50%',
-    refX2: -5,
-    refY2: 0
+    transform: 'translate(calc(w - 5), calc(0.5*h))'
   },
   [ActivityGroup.labelPositionSW]: {
     textVerticalAnchor: 'bottom',
     textAnchor: 'start',
-    refX: '0%',
-    refY: '100%',
-    refX2: 5,
-    refY2: -5
+    transform: 'translate(5, calc(h - 5))'
   },
   [ActivityGroup.labelPositionS]: {
     textVerticalAnchor: 'bottom',
     textAnchor: 'middle',
-    refX: '50%',
-    refY: '100%',
-    refX2: 0,
-    refY2: -5
+    transform: 'translate(calc(0.5 * w), calc(h - 5))'
   },
   [ActivityGroup.labelPositionSE]: {
     textVerticalAnchor: 'bottom',
     textAnchor: 'end',
-    refX: '100%',
-    refY: '100%',
-    refX2: -5,
-    refY2: -5
+    transform: 'translate(calc(w - 5), calc(h - 5))'
   },
   [ActivityGroup.labelPositionDefault]: {
     textVerticalAnchor: 'bottom',
     textAnchor: 'start',
-    refX: '0%',
-    refY: '0%',
-    refX2: 0,
-    refY2: 0
+    transform: 'translate(0, 0)'
   },
   [ActivityGroup.labelPositionLeft]: {
     textVerticalAnchor: 'top',
     textAnchor: 'end',
-    refX: '0%',
-    refY: '0%',
-    refX2: -5,
-    refY2: 5
+    transform: 'translate(-5, 5)'
   },
   [ActivityGroup.labelPositionRight]: {
     textVerticalAnchor: 'top',
     textAnchor: 'start',
-    refX: '100%',
-    refY: '0%',
-    refX2: 5,
-    refY2: 5
+    transform: 'translate(calc(w + 5), 5)'
   }
 }

--- a/Examples/ProcessFlow/src/visualization01/jointjs-manhattan-plus-router.js
+++ b/Examples/ProcessFlow/src/visualization01/jointjs-manhattan-plus-router.js
@@ -1,14 +1,14 @@
 //
 // This router avoids overlaying links on top of one another
 //
-// This is a copy of JointJS routers/manhattan.mjs version 3.4.1
+// This is a copy of JointJS routers/manhattan.mjs version 4.1.3
 // Sections of code that have been altered from the original are marked with
 // // *** Start
 // and
 // // *** End
 //
 // The code has also been altered for imports; these changes have not been marked
-import * as joint from 'jointjs'
+import * as joint from '@joint/core'
 
 // import * as g from '../g/index.mjs';
 // import * as util from '../util/index.mjs';
@@ -22,13 +22,13 @@ const config = {
   // the number of route finding loops that cause the router to abort
   // returns fallback route instead
   //
-  // *** Start of changes from original manhattan router code (JointJS version 3.4.1) ***
+  // *** Start of changes from original manhattan router code (JointJS version 4.1.3) ***
   // Increase loop limit
   maximumLoops: 3000,
 
   // the number of decimal places to round floating point coordinates
   precision: 0,
-  // *** End of changes from original manhattan router code (JointJS version 3.4.1) ***
+  // *** End of changes from original manhattan router code (JointJS version 4.1.3) ***
 
   // maximum change of direction
   maxAllowedDirectionChange: 90,
@@ -42,7 +42,7 @@ const config = {
   excludeEnds: [], // 'source', 'target'
 
   // should certain types of elements not be considered as obstacles?
-  excludeTypes: ['basic.Text'],
+  excludeTypes: [],
 
   // possible starting directions from an element
   startDirections: ['top', 'right', 'bottom', 'left'],
@@ -116,10 +116,10 @@ const config = {
   /* Deprecated */
   // a simple route used in situations when main routing method fails
   // (exceed max number of loop iterations, inaccessible)
-  // *** Start of changes from original manhattan router code (JointJS version 3.4.1) ***
+  // *** Start of changes from original manhattan router code (JointJS version 4.1.3) ***
   // avoid unused variable lint error
   fallbackRoute: function (from, to, opt) { // eslint-disable-line no-unused-vars
-  // *** End of changes from original manhattan router code (JointJS version 3.4.1) ***
+  // *** End of changes from original manhattan router code (JointJS version 4.1.3) ***
     return null // null result will trigger the fallbackRouter
 
     // left for reference:
@@ -140,7 +140,7 @@ const config = {
 // HELPER CLASSES //
 
 //
-// *** Start of changes from original manhattan router code (JointJS version 3.4.1) ***
+// *** Start of changes from original manhattan router code (JointJS version 4.1.3) ***
 // avoid routing lines on top of one another
 //
 // list of connector types not to jump over.
@@ -372,7 +372,7 @@ LineMap.prototype.action = function (startPoint, endPoint, sourcePoint, targetPo
   return returnValue
 }
 
-// *** End of changes from original manhattan router code (JointJS version 3.4.1) ***
+// *** End of changes from original manhattan router code (JointJS version 4.1.3) ***
 
 // Map of obstacles
 // Helper structure to identify whether a point lies inside an obstacle.
@@ -656,10 +656,10 @@ function normalizePoint (point) {
 // PATHFINDING //
 
 // reconstructs a route by concatenating points with their parents
-// *** Start of changes from original manhattan router code (JointJS version 3.4.1) ***
+// *** Start of changes from original manhattan router code (JointJS version 4.1.3) ***
 // avoid unused variable lint error
 function reconstructRoute (parents, points, tailPoint, from, to, grid, opt) { // eslint-disable-line no-unused-vars
-  // *** End of changes from original manhattan router code (JointJS version 3.4.1) ***
+  // *** End of changes from original manhattan router code (JointJS version 4.1.3) ***
   const route = []
 
   let prevDiff = normalizePoint(to.difference(tailPoint))
@@ -680,7 +680,7 @@ function reconstructRoute (parents, points, tailPoint, from, to, grid, opt) { //
     }
 
     //
-    // *** Start of changes from original manhattan router code (JointJS version 3.4.1) ***
+    // *** Start of changes from original manhattan router code (JointJS version 4.1.3) ***
     // avoid infinite loops
     //
     if (currentKey === getKey(parent)) {
@@ -689,7 +689,7 @@ function reconstructRoute (parents, points, tailPoint, from, to, grid, opt) { //
       console.log('and parent:' + JSON.stringify(parent))
       return null
     }
-    // *** End of changes from original manhattan router code (JointJS version 3.4.1) ***
+    // *** End of changes from original manhattan router code (JointJS version 4.1.3) ***
     // parent is assumed to be aligned already
     currentKey = getKey(parent)
     parent = parents[currentKey]
@@ -788,11 +788,11 @@ function getRectPoints (anchor, bbox, directionList, grid, opt) {
 // finds the route between two points/rectangles (`from`, `to`) implementing A* algorithm
 // rectangles get rect points assigned by getRectPoints()
 //
-// *** Start of changes from original manhattan router code (JointJS version 3.4.1) ***
+// *** Start of changes from original manhattan router code (JointJS version 4.1.3) ***
 // avoid routing lines on top of one another
 //
 function findRoute (from, to, isPointObstacle, lineMap, opt) {
-// *** End of changes from original manhattan router code (JointJS version 3.4.1) ***
+// *** End of changes from original manhattan router code (JointJS version 4.1.3) ***
   const precision = opt.precision
 
   // Get grid for this route.
@@ -934,7 +934,7 @@ function findRoute (from, to, isPointObstacle, lineMap, opt) {
         if (openSet.isClose(neighborKey) || isPointObstacle(neighborPoint)) continue
 
         //
-        // *** Start of changes from original manhattan router code (JointJS version 3.4.1) ***
+        // *** Start of changes from original manhattan router code (JointJS version 4.1.3) ***
         // avoid routing lines on top of one another
         //
         const action = lineMap.action(currentPoint, neighborPoint, sourceAnchor, targetAnchor)
@@ -992,7 +992,7 @@ function findRoute (from, to, isPointObstacle, lineMap, opt) {
           opt.previousDirectionAngle = previousDirectionAngle
           return reconstructRoute(parents, points, newPoint, start, end, grid, opt)
         }
-        // *** End of changes from original manhattan router code (JointJS version 3.4.1) ***
+        // *** End of changes from original manhattan router code (JointJS version 4.1.3) ***
 
         // We can only enter end points at an acceptable angle.
         if (endPointsKeys.indexOf(neighborKey) >= 0) { // neighbor is an end point
@@ -1080,15 +1080,16 @@ function router (vertices, opt, linkView) {
     map.build(linkView.paper.model, linkView.model)
     isPointObstacle = (point) => !map.isPointAccessible(point)
   }
+
   const oldVertices = joint.util.toArray(vertices).map(joint.g.Point)
   const newVertices = []
   let tailPoint = sourceAnchor // the origin of first route's grid, does not need snapping
   //
-  // *** Start of changes from original manhattan router code (JointJS version 3.4.1) ***
+  // *** Start of changes from original manhattan router code (JointJS version 4.1.3) ***
   // avoid routing lines on top of one another
   //
   const lineMap = (new LineMap(opt)).build(linkView.paper, linkView.model)
-  // *** End of changes from original manhattan router code (JointJS version 3.4.1) ***
+  // *** End of changes from original manhattan router code (JointJS version 4.1.3) ***
 
   // find a route by concatenating all partial routes (routes need to pass through vertices)
   // source -> vertex[1] -> ... -> vertex[n] -> target
@@ -1122,7 +1123,7 @@ function router (vertices, opt, linkView) {
 
     // if partial route has not been calculated yet use the main routing method to find one
     //
-    // *** Start of changes from original manhattan router code (JointJS version 3.4.1) ***
+    // *** Start of changes from original manhattan router code (JointJS version 4.1.3) ***
     // avoid routing lines on top of one another
     //
     partialRoute = partialRoute || findRoute.call(linkView, from, to, isPointObstacle, lineMap, opt)
@@ -1141,7 +1142,7 @@ function router (vertices, opt, linkView) {
       }
       return retRoute
     }
-    // *** End of changes from original manhattan router code (JointJS version 3.4.1) ***
+    // *** End of changes from original manhattan router code (JointJS version 4.1.3) ***
 
     const leadPoint = partialRoute[0]
 
@@ -1158,9 +1159,9 @@ function router (vertices, opt, linkView) {
 }
 
 // public function
-// *** Start of changes from original manhattan router code (JointJS version 3.4.1) ***
+// *** Start of changes from original manhattan router code (JointJS version 4.1.3) ***
 export const manhattanPlus = function (vertices, opt, linkView) {
   const routePoints = router(vertices, joint.util.assign({}, config, opt), linkView)
   return routePoints
 }
-// *** End of changes from original manhattan router code (JointJS version 3.4.1) ***
+// *** End of changes from original manhattan router code (JointJS version 4.1.3) ***

--- a/Examples/ProcessFlow/src/visualization01/jointjs-merge-jumpover.js
+++ b/Examples/ProcessFlow/src/visualization01/jointjs-merge-jumpover.js
@@ -1,7 +1,7 @@
 //
 // This connector avoids unwanted jumpovers at the intersections of links with the same target anchor point
 //
-// This is a copy of JointJS connectors/jumpover.mjs version 3.4.3
+// This is a copy of JointJS connectors/jumpover.mjs version 4.1.3
 // Sections of code that have been altered from the original are marked with
 // // *** Start
 // and
@@ -9,7 +9,7 @@
 //
 // The code has also been altered for imports; these changes have not been marked
 
-import * as joint from 'jointjs'
+import * as joint from '@joint/core'
 // import * as util from '../util/index.mjs';
 // import * as g from '../g/index.mjs';
 
@@ -32,6 +32,43 @@ const IGNORED_CONNECTORS = ['smooth']
 // internal constants for round segment
 const _13 = 1 / 3
 const _23 = 2 / 3
+
+function sortPointsAscending (p1, p2) {
+  let { x: x1, y: y1 } = p1
+  let { x: x2, y: y2 } = p2
+
+  if (x1 > x2) {
+    let swap = x1
+    x1 = x2
+    x2 = swap
+
+    swap = y1
+    y1 = y2
+    y2 = swap
+  }
+
+  if (y1 > y2) {
+    let swap = x1
+    x1 = x2
+    x2 = swap
+
+    swap = y1
+    y1 = y2
+    y2 = swap
+  }
+
+  return [new joint.g.Point(x1, y1), new joint.g.Point(x2, y2)]
+}
+
+function overlapExists (line1, line2) {
+  const [{ x: x1, y: y1 }, { x: x2, y: y2 }] = sortPointsAscending(line1.start, line1.end)
+  const [{ x: x3, y: y3 }, { x: x4, y: y4 }] = sortPointsAscending(line2.start, line2.end)
+
+  const xMatch = x1 <= x4 && x3 <= x2
+  const yMatch = y1 <= y4 && y3 <= y2
+
+  return xMatch && yMatch
+}
 
 /**
  * Transform start/end and route into series of lines
@@ -104,7 +141,7 @@ function updateJumpOver (paper) {
  * @return {joint.g.point[]} list of intersection points
  */
 //
-// *** Start of changes from original jumpover connector code (JointJS version 3.4.3) ***
+// *** Start of changes from original jumpover connector code (JointJS version 4.1.3) ***
 // avoid jumping over links where the intersection is at the end of either of the intersecting lines
 // limit jumps to be all on horizontal lines or all on vertical lines
 //
@@ -118,7 +155,7 @@ function findLineIntersections (line, crossCheckLines, jumpOverOnHorizontalLines
        !intersection.round().equals(line.end.round()) &&
        !intersection.round().equals(crossCheckLine.start.round()) &&
        !intersection.round().equals(crossCheckLine.end.round())) {
-    // *** End of changes from original jumpover connector code (JointJS version 3.4.3) ***
+    // *** End of changes from original jumpover connector code (JointJS version 4.1.3) ***
       res.push(intersection)
     }
     return res
@@ -127,8 +164,8 @@ function findLineIntersections (line, crossCheckLines, jumpOverOnHorizontalLines
 
 /**
  * Sorting function for list of points by their distance.
- * @param {joint.g.point} p1 first point
- * @param {joint.g.point} p2 second point
+ * @param {joint.g.Point} p1 first point
+ * @param {joint.g.Point} p2 second point
  * @return {number} squared distance between points
  */
 function sortPoints (p1, p2) {
@@ -138,7 +175,7 @@ function sortPoints (p1, p2) {
 /**
  * Split input line into multiple based on intersection points.
  * @param {joint.g.line} line input line to split
- * @param {joint.g.point[]} intersections points where to split the line
+ * @param {joint.g.Point[]} intersections points where to split the line
  * @param {number} jumpSize the size of jump arc (length empty spot on a line)
  * @return {joint.g.line[]} list of lines being split
  */
@@ -158,7 +195,7 @@ function createJumps (line, intersections, jumpSize) {
     let jumpEnd = joint.g.point(point).move(lastLine.start, +(jumpSize))
 
     //
-    // *** Start of changes from original jumpover connector code (JointJS version 3.4.3) ***
+    // *** Start of changes from original jumpover connector code (JointJS version 4.1.3) ***
     // handle jumping over more than 2 parallel lines
     //
     // now try to look at the next intersection points
@@ -183,7 +220,7 @@ function createJumps (line, intersections, jumpSize) {
       }
     }
     if (!moreIntersections) {
-      // *** End of changes from original jumpover connector code (JointJS version 3.4.3) ***
+      // *** End of changes from original jumpover connector code (JointJS version 4.1.3) ***
       // this block is inside of `if` as an optimization so the distance is
       // not calculated when we know there are no other intersection points
       const endDistance = jumpStart.distance(lastLine.end)
@@ -333,8 +370,6 @@ function buildRoundedSegment (offset, path, curr, prev, next) {
  * @return {string} created `D` attribute of SVG path
  */
 export const mergeJumpover = function (sourcePoint, targetPoint, route, opt) { // eslint-disable-line max-params
-  // console.log('Link target: ' + JSON.stringify(targetPoint))
-
   setupUpdating(this)
 
   const raw = opt.raw
@@ -343,12 +378,12 @@ export const mergeJumpover = function (sourcePoint, targetPoint, route, opt) { /
   const radius = opt.radius || RADIUS
   const ignoreConnectors = opt.ignoreConnectors || IGNORED_CONNECTORS
   //
-  // *** Start of changes from original jumpover connector code (JointJS version 3.4.3) ***
+  // *** Start of changes from original jumpover connector code (JointJS version 4.1.3) ***
   // avoid jumping over links where the intersection is at the end of either of the intersecting lines
   // limit jumps to be all on horizontal lines or all on vertical lines
   //
   const jumpOverOnHorizontalLines = opt.jumpOverOnHorizontalLines
-  // *** End of changes from original jumpover connector code (JointJS version 3.4.3) ***
+  // *** End of changes from original jumpover connector code (JointJS version 4.1.3) ***
 
   // grab the first jump type as a default if specified one is invalid
   if (JUMP_TYPES.indexOf(jumpType) === -1) {
@@ -369,18 +404,18 @@ export const mergeJumpover = function (sourcePoint, targetPoint, route, opt) { /
 
   const thisModel = this.model
   //
-  // *** Start of changes from original jumpover connector code (JointJS version 3.4.3) ***
+  // *** Start of changes from original jumpover connector code (JointJS version 4.1.3) ***
   // avoid jumping over links where the intersection is at the end of either of the intersecting lines
   // limit jumps to be all on horizontal lines or all on vertical lines
   //
   // const thisIndex = allLinks.indexOf(thisModel)
-  // *** End of changes from original jumpover connector code (JointJS version 3.4.3) ***
+  // *** End of changes from original jumpover connector code (JointJS version 4.1.3) ***
   const defaultConnector = paper.options.defaultConnector || {}
 
   // not all links are meant to be jumped over.
-  // *** Start of changes from original jumpover connector code (JointJS version 3.4.3) ***
+  // *** Start of changes from original jumpover connector code (JointJS version 4.1.3) ***
   const links = allLinks.filter(function (link, idx) { // eslint-disable-line no-unused-vars
-  // *** End of changes from original jumpover connector code (JointJS version 3.4.3) ***
+  // *** End of changes from original jumpover connector code (JointJS version 4.1.3) ***
     const connector = link.get('connector') || defaultConnector
 
     // avoid jumping over links with connector type listed in `ignored connectors`.
@@ -388,7 +423,7 @@ export const mergeJumpover = function (sourcePoint, targetPoint, route, opt) { /
     if (joint.util.toArray(ignoreConnectors).includes(connector.name)) {
       return false
     }
-    // *** Start of changes from original jumpover connector code (JointJS version 3.4.3) ***
+    // *** Start of changes from original jumpover connector code (JointJS version 4.1.3) ***
     // avoid jumping over links where the intersection is at the end of either of the intersecting lines
     // limit jumps to be all on horizontal lines or all on vertical lines
     //
@@ -397,7 +432,7 @@ export const mergeJumpover = function (sourcePoint, targetPoint, route, opt) { /
     // if (idx > thisIndex) {
     //   return false //connector.name !== 'mergeJumpoverConnector'
     // }
-    // *** End of changes from original jumpover connector code (JointJS version 3.4.3) ***
+    // *** End of changes from original jumpover connector code (JointJS version 4.1.3) ***
     return true
   })
 
@@ -433,17 +468,24 @@ export const mergeJumpover = function (sourcePoint, targetPoint, route, opt) { /
   const jumpingLines = thisLines.reduce(function (resultLines, thisLine) {
     // iterate all links and grab the intersections with this line
     // these are then sorted by distance so the line can be split more easily
-
     const intersections = links.reduce(function (res, link, i) {
       // don't intersection with itself
       if (link !== thisModel) {
+        const linkLinesToTest = linkLines[i].slice()
+        const overlapIndex = linkLinesToTest.findIndex((line) => overlapExists(thisLine, line))
+
+        // Overlap occurs and the end point of one segment lies on thisLine
+        if (overlapIndex > -1 && thisLine.containsPoint(linkLinesToTest[overlapIndex].end)) {
+          // Remove the next segment because there will never be a jump
+          linkLinesToTest.splice(overlapIndex + 1, 1)
+        }
         //
-        // *** Start of changes from original jumpover connector code (JointJS version 3.4.3) ***
+        // *** Start of changes from original jumpover connector code (JointJS version 4.1.3) ***
         // avoid jumping over links where the intersection is at the end of either of the intersecting lines
         // limit jumps to be all on horizontal lines or all on vertical lines
         //
-        const lineIntersections = findLineIntersections(thisLine, linkLines[i], jumpOverOnHorizontalLines)
-        // *** End of changes from original jumpover connector code (JointJS version 3.4.3) ***
+        const lineIntersections = findLineIntersections(thisLine, linkLinesToTest, jumpOverOnHorizontalLines)
+        // *** End of changes from original jumpover connector code (JointJS version 4.1.3) ***
         res.push.apply(res, lineIntersections)
       }
       return res

--- a/Examples/ProcessFlow/src/visualization01/jointjs-shapes.js
+++ b/Examples/ProcessFlow/src/visualization01/jointjs-shapes.js
@@ -643,8 +643,11 @@ function defineSubProcess (gridSize, elementSize, verticalSwimlanes) {
         height: 'calc(h)'
       },
       label: {
-        refWidth: 0.8,
-        refHeight: 1,
+        textWrap: {
+          width: 'calc(0.8*w)',
+          height: 'calc(h)',
+          ellipsis: false
+        },
         textVerticalAnchor: 'middle',
         textAnchor: 'middle',
         transform: 'translate(calc(0.5 * w), calc(0.5 * h))'
@@ -689,8 +692,11 @@ function defineProcess () {
         height: 'calc(h)'
       },
       label: {
-        refWidth: 0.8,
-        refHeight: 1,
+        textWrap: {
+          width: 'calc(0.8*w)',
+          height: 'calc(h)',
+          ellipsis: false
+        },
         textVerticalAnchor: 'middle',
         textAnchor: 'middle',
         transform: 'translate(calc(0.5 * w), calc(0.5 * h))'
@@ -822,10 +828,11 @@ function defineDecision (verticalSwimlanes) {
       label: {
         textVerticalAnchor: 'middle',
         textAnchor: 'middle',
-        // width: 'calc(w)',
-        // height: 'calc(h)',
-        refWidth: 0.95,
-        refHeight: 0.95,
+        textWrap: {
+          width: 'calc(0.95*w)',
+          height: 'calc(0.95*h)',
+          ellipsis: false
+        },
         transform: 'translate(calc(0.5 * w), calc(0.5 * h))'
       },
       title: {
@@ -921,7 +928,11 @@ function defineExternalData () {
         textVerticalAnchor: 'middle',
         textAnchor: 'middle',
         transform: 'translate(calc(0.4 * w), calc(0.5 * h))',
-        refWidth: 0.8
+        textWrap: {
+          width: 'calc(0.8*w)',
+          height: 'calc(h)',
+          ellipsis: false
+        },
       },
       title: {
       }
@@ -959,7 +970,11 @@ function defineDatabase () {
         textVerticalAnchor: 'middle',
         textAnchor: 'middle',
         transform: 'translate(calc(0.35 * w), calc(0.5 * h))',
-        refWidth: 0.8
+        textWrap: {
+          width: 'calc(0.8*w)',
+          height: 'calc(h)',
+          ellipsis: false
+        },
       },
       title: {
       }
@@ -996,7 +1011,6 @@ function defineDocument () {
         textVerticalAnchor: 'middle',
         textAnchor: 'middle',
         transform: 'translate(calc(0.5 * w), calc(0.4 * h))',
-        refWidth: 1.0
       },
       title: {
       }
@@ -1032,7 +1046,6 @@ function defineData () {
         textVerticalAnchor: 'middle',
         textAnchor: 'middle',
         transform: 'translate(calc(0.5 * w), calc(0.5 * h))',
-        refWidth: 1.0
       },
       title: {
       }
@@ -1068,7 +1081,6 @@ function defineOther () {
         textVerticalAnchor: 'middle',
         textAnchor: 'middle',
         transform: 'translate(calc(0.5 * w), calc(0.6 * h))',
-        refWidth: 1.0
       },
       title: {
       }
@@ -1105,8 +1117,11 @@ function defineOffPageOutput () {
         textVerticalAnchor: 'middle',
         textAnchor: 'middle',
         transform: 'translate(calc(0.5 * w), calc(0.33 * h))',
-        refWidth: 1.0,
-        refHeight: 0.75
+        textWrap: {
+          width: 'calc(w)',
+          height: 'calc(0.75*h)',
+          ellipsis: false
+        },
       },
       title: {
       }
@@ -1143,8 +1158,11 @@ function defineOffPageInput () {
         textVerticalAnchor: 'middle',
         textAnchor: 'middle',
         transform: 'translate(calc(0.5 * w), calc(0.33 * h))',
-        refWidth: 1.0,
-        refHeight: 0.75
+        textWrap: {
+          width: 'calc(w)',
+          height: 'calc(0.75*h)',
+          ellipsis: false
+        },
       },
       title: {
       }
@@ -1176,7 +1194,6 @@ function defineStepGroup () {
       label: {
         textVerticalAnchor: 'bottom',
         textAnchor: 'start',
-        refWidth: 1.0
       }
     }
   }, {

--- a/Examples/ProcessFlow/src/visualization01/jointjs-shapes.js
+++ b/Examples/ProcessFlow/src/visualization01/jointjs-shapes.js
@@ -1,4 +1,4 @@
-import * as joint from 'jointjs'
+import * as joint from '@joint/core'
 import * as Ports from './element-port-names'
 import * as Types from './element-types'
 import { OrientedDimensions, OrientedCoords } from './oriented'
@@ -266,8 +266,8 @@ export function createAssociation (id) {
 function defineActor (renderSwimlaneWatermarks, verticalSwimlanes) {
   const attrs = {
     body: {
-      refWidth: 1,
-      refHeight: 1,
+      width: 'calc(w)',
+      height: 'calc(h)',
       even: 'false'
     }
   }
@@ -285,7 +285,7 @@ function defineActor (renderSwimlaneWatermarks, verticalSwimlanes) {
     }
     if (verticalSwimlanes) {
       attrs.text = {
-        refX: 0.5,
+        x: 'calc(0.5*w)',
         y: 2,
         textVerticalAnchor: 'top',
         textAnchor: 'middle'
@@ -299,8 +299,8 @@ function defineActor (renderSwimlaneWatermarks, verticalSwimlanes) {
       }
     }
     attrs.watermark = {
-      refWidth: 1,
-      refHeight: 1,
+      width: 'calc(w)',
+      height: 'calc(h)',
       fillOpacity: 0
     }
     markup.push({
@@ -337,8 +337,8 @@ function defineSwimlane () {
   return joint.dia.Element.define('MooD.Swimlane', {
     attrs: {
       body: {
-        refWidth: 1,
-        refHeight: 1,
+        width: 'calc(w)',
+        height: 'calc(h)',
         fillOpacity: 0
       }
     }
@@ -474,14 +474,13 @@ function defineStart (verticalSwimlanes) {
       body: {
         rx: 20,
         refRy: '50%',
-        refWidth: 1,
-        refHeight: 1
+        width: 'calc(w)',
+        height: 'calc(h)'
       },
       label: {
         textVerticalAnchor: 'middle',
         textAnchor: 'middle',
-        refX: 0.5,
-        refY: 0.5
+        transform: 'translate(calc(0.5 * w), calc(0.5 * h))'
       },
       title: {
       }
@@ -635,22 +634,20 @@ function defineSubProcess (gridSize, elementSize, verticalSwimlanes) {
     },
     attrs: {
       body: {
-        refX: 0,
-        refWidth: 1,
-        refHeight: 1
+        width: 'calc(w)',
+        height: 'calc(h)'
       },
       inner: {
-        refX: 0.1,
-        refWidth: 0.8,
-        refHeight: 1
+        x: 'calc(0.1*w)',
+        width: 'calc(0.8*w)',
+        height: 'calc(h)'
       },
       label: {
         refWidth: 0.8,
         refHeight: 1,
         textVerticalAnchor: 'middle',
         textAnchor: 'middle',
-        refX: 0.5,
-        refY: 0.5
+        transform: 'translate(calc(0.5 * w), calc(0.5 * h))'
       },
       title: {
       }
@@ -683,22 +680,20 @@ function defineProcess () {
   return joint.dia.Element.define('MooD.Process', {
     attrs: {
       body: {
-        refX: 0,
-        refWidth: 1,
-        refHeight: 1
+        width: 'calc(w)',
+        height: 'calc(h)'
       },
       inner: {
-        refX: 0.1,
-        refWidth: 0.8,
-        refHeight: 1
+        x: 'calc(0.1*w)',
+        width: 'calc(0.8*w)',
+        height: 'calc(h)'
       },
       label: {
         refWidth: 0.8,
         refHeight: 1,
         textVerticalAnchor: 'middle',
         textAnchor: 'middle',
-        refX: 0.5,
-        refY: 0.5
+        transform: 'translate(calc(0.5 * w), calc(0.5 * h))'
       },
       title: {
       }
@@ -737,14 +732,13 @@ function defineProcessStep (gridSize, elementSize, verticalSwimlanes) {
     },
     attrs: {
       body: {
-        refWidth: 1,
-        refHeight: 1
+        width: 'calc(w)',
+        height: 'calc(h)'
       },
       label: {
         textVerticalAnchor: 'middle',
         textAnchor: 'middle',
-        refX: 0.5,
-        refY: 0.5,
+        transform: 'translate(calc(0.5 * w), calc(0.5 * h))',
         fontSize: ''
       },
       title: {
@@ -819,7 +813,7 @@ function defineDecision (verticalSwimlanes) {
       ]
     },
     attrs: {
-      path: {
+      body: {
         refDResetOffset:
                   'M 50 0 L 100 50 ' +
                   'L 50 100 ' +
@@ -828,28 +822,30 @@ function defineDecision (verticalSwimlanes) {
       label: {
         textVerticalAnchor: 'middle',
         textAnchor: 'middle',
+        // width: 'calc(w)',
+        // height: 'calc(h)',
         refWidth: 0.95,
         refHeight: 0.95,
-        refX: 0.5,
-        refY: 0.5
+        transform: 'translate(calc(0.5 * w), calc(0.5 * h))'
       },
       title: {
       }
     }
   }, {
-    markup: [{
-      tagName: 'path',
-      selector: 'body',
-      groupSelector: 'bodyGroup',
-      className: 'mood-graph-step'
-    }, {
-      tagName: 'text',
-      selector: 'label',
-      className: 'mood-graph-step-label'
-    }, {
-      tagName: 'title',
-      selector: 'title'
-    }]
+    markup: [
+      {
+        tagName: 'path',
+        selector: 'body',
+        groupSelector: 'bodyGroup',
+        className: 'mood-graph-step'
+      }, {
+        tagName: 'text',
+        selector: 'label',
+        className: 'mood-graph-step-label'
+      }, {
+        tagName: 'title',
+        selector: 'title'
+      }]
   })
 }
 
@@ -857,14 +853,13 @@ function defineVerticalLabel (verticalSwimlanes) {
   const labelDefaults = {
     attrs: {
       body: {
-        refWidth: 1,
-        refHeight: 1
+        width: 'calc(w)',
+        height: 'calc(h)'
       },
       label: {
         textVerticalAnchor: 'middle',
         textAnchor: 'middle',
-        refX: 0.5,
-        refY: 0.5
+        transform: 'translate(calc(0.5 * w), calc(0.5 * h))'
       },
       title: {
       }
@@ -884,7 +879,7 @@ function defineVerticalLabel (verticalSwimlanes) {
     }]
   }
   if (verticalSwimlanes) {
-    labelDefaults.attrs.label.transform = 'rotate(-90)'
+    labelDefaults.attrs.label.transform += ' rotate(-90)'
   }
   return joint.dia.Element.define('MooD.VLabel', labelDefaults, labelProtoProps)
 }
@@ -898,7 +893,7 @@ function definePhaseExtent (verticalSwimlanes) {
   }
   return joint.dia.Element.define('MooD.PhaseExtent', {
     attrs: {
-      path: {
+      body: {
         refDResetOffset:
                   path
       }
@@ -915,7 +910,7 @@ function definePhaseExtent (verticalSwimlanes) {
 function defineExternalData () {
   return joint.dia.Element.define('MooD.ExternalData', {
     attrs: {
-      path: {
+      body: {
         refDResetOffset:
                   'M 20 0 L 100 0 ' +
                   'A 20 20 0 0 0 100 40 ' +
@@ -925,8 +920,7 @@ function defineExternalData () {
       label: {
         textVerticalAnchor: 'middle',
         textAnchor: 'middle',
-        refX: 0.4,
-        refY: 0.5,
+        transform: 'translate(calc(0.4 * w), calc(0.5 * h))',
         refWidth: 0.8
       },
       title: {
@@ -952,7 +946,7 @@ function defineExternalData () {
 function defineDatabase () {
   return joint.dia.Element.define('MooD.Database', {
     attrs: {
-      path: {
+      body: {
         refDResetOffset:
                   'M 20 0 L 100 0 ' +
                   'A 20 20 0 0 0 100 40 ' +
@@ -964,8 +958,7 @@ function defineDatabase () {
       label: {
         textVerticalAnchor: 'middle',
         textAnchor: 'middle',
-        refX: 0.35,
-        refY: 0.5,
+        transform: 'translate(calc(0.35 * w), calc(0.5 * h))',
         refWidth: 0.8
       },
       title: {
@@ -991,7 +984,7 @@ function defineDatabase () {
 function defineDocument () {
   return joint.dia.Element.define('MooD.Document', {
     attrs: {
-      path: {
+      body: {
         refDResetOffset:
                   'M 0 0 L 100 0 ' +
                   'L 100 35 ' +
@@ -1002,8 +995,7 @@ function defineDocument () {
       label: {
         textVerticalAnchor: 'middle',
         textAnchor: 'middle',
-        refX: 0.5,
-        refY: 0.4,
+        transform: 'translate(calc(0.5 * w), calc(0.4 * h))',
         refWidth: 1.0
       },
       title: {
@@ -1029,7 +1021,7 @@ function defineDocument () {
 function defineData () {
   return joint.dia.Element.define('MooD.Data', {
     attrs: {
-      path: {
+      body: {
         refDResetOffset:
                   'M 20 0 L 100 0 ' +
                   'L 80 40 ' +
@@ -1039,8 +1031,7 @@ function defineData () {
       label: {
         textVerticalAnchor: 'middle',
         textAnchor: 'middle',
-        refX: 0.5,
-        refY: 0.5,
+        transform: 'translate(calc(0.5 * w), calc(0.5 * h))',
         refWidth: 1.0
       },
       title: {
@@ -1066,7 +1057,7 @@ function defineData () {
 function defineOther () {
   return joint.dia.Element.define('MooD.Other', {
     attrs: {
-      path: {
+      body: {
         refDResetOffset:
                   'M 0 10 L 100 0 ' +
                   'L 100 40 ' +
@@ -1076,8 +1067,7 @@ function defineOther () {
       label: {
         textVerticalAnchor: 'middle',
         textAnchor: 'middle',
-        refX: 0.5,
-        refY: 0.6,
+        transform: 'translate(calc(0.5 * w), calc(0.6 * h))',
         refWidth: 1.0
       },
       title: {
@@ -1103,7 +1093,7 @@ function defineOther () {
 function defineOffPageOutput () {
   return joint.dia.Element.define('MooD.OffPageOutput', {
     attrs: {
-      path: {
+      body: {
         refDResetOffset:
                   'L 100 0 ' +
                   'L 100 30 ' +
@@ -1114,8 +1104,7 @@ function defineOffPageOutput () {
       label: {
         textVerticalAnchor: 'middle',
         textAnchor: 'middle',
-        refX: 0.5,
-        refY: 0.33,
+        transform: 'translate(calc(0.5 * w), calc(0.33 * h))',
         refWidth: 1.0,
         refHeight: 0.75
       },
@@ -1142,7 +1131,7 @@ function defineOffPageOutput () {
 function defineOffPageInput () {
   return joint.dia.Element.define('MooD.OffPageInput', {
     attrs: {
-      path: {
+      body: {
         refDResetOffset:
                   'L 100 0 ' +
                   'L 100 40 ' +
@@ -1153,8 +1142,7 @@ function defineOffPageInput () {
       label: {
         textVerticalAnchor: 'middle',
         textAnchor: 'middle',
-        refX: 0.5,
-        refY: 0.33,
+        transform: 'translate(calc(0.5 * w), calc(0.33 * h))',
         refWidth: 1.0,
         refHeight: 0.75
       },
@@ -1182,14 +1170,12 @@ function defineStepGroup () {
   return joint.dia.Element.define('MooD.StepGroup', {
     attrs: {
       body: {
-        refWidth: 1,
-        refHeight: 1
+        width: 'calc(w)',
+        height: 'calc(h)'
       },
       label: {
         textVerticalAnchor: 'bottom',
         textAnchor: 'start',
-        refX: '0%',
-        refY: '0%',
         refWidth: 1.0
       }
     }
@@ -1255,14 +1241,13 @@ function buildBPMNEvent (gridSize, elementSize, verticalSwimlanes, eventClass, e
       items: portItems
     },
     attrs: {
-      path: {
+      body: {
         refDResetOffset: symbolPath
       },
       label: {
         textVerticalAnchor: 'top',
         textAnchor: 'middle',
-        refX: 0.5,
-        refY: 0.99,
+        transform: 'translate(calc(0.5 * w), calc(0.99 * h))',
         refWidth: 2.0,
         refHeight: 2.0
       },
@@ -1474,7 +1459,7 @@ function defineBPMNExclusiveGateway (verticalSwimlanes) {
       ]
     },
     attrs: {
-      path: {
+      body: {
         refDResetOffset:
                   'M 50 0 L 100 50 ' +
                   'L 50 100 ' +
@@ -1485,8 +1470,7 @@ function defineBPMNExclusiveGateway (verticalSwimlanes) {
       label: {
         textVerticalAnchor: 'top',
         textAnchor: 'middle',
-        refX: 0.5,
-        refY: 0.99,
+        transform: 'translate(calc(0.5 * w), calc(0.99 * h))',
         refWidth: 2.0,
         refHeight: 2.0
       },
@@ -1562,7 +1546,7 @@ function defineBPMNParallelGateway (verticalSwimlanes) {
       ]
     },
     attrs: {
-      path: {
+      body: {
         refDResetOffset:
                   'M 50 0 L 100 50 ' +
                   'L 50 100 ' +
@@ -1573,8 +1557,7 @@ function defineBPMNParallelGateway (verticalSwimlanes) {
       label: {
         textVerticalAnchor: 'top',
         textAnchor: 'middle',
-        refX: 0.5,
-        refY: 0.99,
+        transform: 'translate(calc(0.5 * w), calc(0.99 * h))',
         refWidth: 2.0,
         refHeight: 2.0
       },
@@ -1650,7 +1633,7 @@ function defineBPMNInclusiveGateway (verticalSwimlanes) {
       ]
     },
     attrs: {
-      path: {
+      body: {
         refDResetOffset:
             'M 50 0 l -50 50' + // Draw diamond (anti-clockwise)
             'l 50 50 ' +
@@ -1662,8 +1645,7 @@ function defineBPMNInclusiveGateway (verticalSwimlanes) {
       label: {
         textVerticalAnchor: 'top',
         textAnchor: 'middle',
-        refX: 0.5,
-        refY: 0.99,
+        transform: 'translate(calc(0.5 * w), calc(0.99 * h))',
         refWidth: 2.0,
         refHeight: 2.0
       },
@@ -1716,14 +1698,13 @@ function buildBPMNDataObject (gridSize, elementSize, verticalSwimlanes, styleNam
   const portItems = processPortItems()
   const bodyClass = 'bpmn-data-object'
   const attrs = {
-    path: {
+    body: {
       refDResetOffset: artefactPath
     },
     label: {
       textVerticalAnchor: 'top',
       textAnchor: 'middle',
-      refX: 0.5,
-      refY: 0.99,
+      transform: 'translate(calc(0.5 * w), calc(0.99 * h))',
       refWidth: 2.0,
       refHeight: 2.0
     },
@@ -1752,16 +1733,14 @@ function buildBPMNDataObject (gridSize, elementSize, verticalSwimlanes, styleNam
       fill: 'none',
       stroke: 'none',
       ref: 'body',
-      refWidth: 0.45,
-      refHeight: 0.25,
-      refX: 0.1,
-      refY: 0.1
+      width: 'calc(0.45*w)',
+      height: 'calc(0.25*h)',
+      transform: 'translate(calc(0.1 * w), calc(0.1 * h))'
     }
     attrs.inner = {
       ref: 'styleBox',
       refDResetOffset: stylePath,
-      refX: 0.0,
-      refY: 0.1
+      transform: 'translate(0, calc(0.1 * h))'
     }
     markup.push({
       tagName: 'rect',
@@ -1823,14 +1802,13 @@ function defineBPMNDataStorage (gridSize, elementSize, verticalSwimlanes) {
       items: portItems
     },
     attrs: {
-      path: {
+      body: {
         refDResetOffset: symbolPath
       },
       label: {
         textVerticalAnchor: 'top',
         textAnchor: 'middle',
-        refX: 0.5,
-        refY: 0.99,
+        transform: 'translate(calc(0.5 * w), calc(0.99 * h))',
         refWidth: 2.0,
         refHeight: 2.0
       },

--- a/Examples/ProcessFlow/src/visualization01/jointjs-shapes.js
+++ b/Examples/ProcessFlow/src/visualization01/jointjs-shapes.js
@@ -932,7 +932,7 @@ function defineExternalData () {
           width: 'calc(0.8*w)',
           height: 'calc(h)',
           ellipsis: false
-        },
+        }
       },
       title: {
       }
@@ -974,7 +974,7 @@ function defineDatabase () {
           width: 'calc(0.8*w)',
           height: 'calc(h)',
           ellipsis: false
-        },
+        }
       },
       title: {
       }
@@ -1010,7 +1010,7 @@ function defineDocument () {
       label: {
         textVerticalAnchor: 'middle',
         textAnchor: 'middle',
-        transform: 'translate(calc(0.5 * w), calc(0.4 * h))',
+        transform: 'translate(calc(0.5 * w), calc(0.4 * h))'
       },
       title: {
       }
@@ -1045,7 +1045,7 @@ function defineData () {
       label: {
         textVerticalAnchor: 'middle',
         textAnchor: 'middle',
-        transform: 'translate(calc(0.5 * w), calc(0.5 * h))',
+        transform: 'translate(calc(0.5 * w), calc(0.5 * h))'
       },
       title: {
       }
@@ -1080,7 +1080,7 @@ function defineOther () {
       label: {
         textVerticalAnchor: 'middle',
         textAnchor: 'middle',
-        transform: 'translate(calc(0.5 * w), calc(0.6 * h))',
+        transform: 'translate(calc(0.5 * w), calc(0.6 * h))'
       },
       title: {
       }
@@ -1121,7 +1121,7 @@ function defineOffPageOutput () {
           width: 'calc(w)',
           height: 'calc(0.75*h)',
           ellipsis: false
-        },
+        }
       },
       title: {
       }
@@ -1162,7 +1162,7 @@ function defineOffPageInput () {
           width: 'calc(w)',
           height: 'calc(0.75*h)',
           ellipsis: false
-        },
+        }
       },
       title: {
       }
@@ -1193,7 +1193,7 @@ function defineStepGroup () {
       },
       label: {
         textVerticalAnchor: 'bottom',
-        textAnchor: 'start',
+        textAnchor: 'start'
       }
     }
   }, {

--- a/Examples/ProcessFlow/src/visualization01/visualization.config.json.ejs
+++ b/Examples/ProcessFlow/src/visualization01/visualization.config.json.ejs
@@ -3,7 +3,7 @@
   "name": "Process Flow Visualisation",
   "description": "Visualisation of a Process Flow in swimlanes",
   "version": "<%= package.version %>",
-  "supportedVersions": "2.6",
+  "supportedVersions": "2",
   "moodVersion": "16.0.082",
   "dynamicData": false,
   "canOverflow":  true,

--- a/Examples/ProcessFlow/src/visualization02/visualization.config.json.ejs
+++ b/Examples/ProcessFlow/src/visualization02/visualization.config.json.ejs
@@ -3,7 +3,7 @@
   "name": "Process Flow Header",
   "description": "Header for a Process Flow",
   "version": "<%= package.version %>",
-  "supportedVersions": "2.6",
+  "supportedVersions": "2",
   "moodVersion": "16.0.82",
   "dynamicData": false,
   "canOverflow": true,

--- a/Examples/ProcessFlow/test/visualization01/data-bp108.json
+++ b/Examples/ProcessFlow/test/visualization01/data-bp108.json
@@ -509,7 +509,7 @@
 			{
 				"id": "41-5AE6BBFDCFBC4FA6AF4F2DBA16FDD4DA", 
 				"target": {"id": "55-2DD9764D4BD24D3E96343641A40F21C4", "name": "01."}, 
-				"source": {"id": "55-63A12E17574C48029310ED0DB4AA17D9", "name": "Completed Test Forms", "shortName": null, "type": "Data", "navigable": false}, 
+				"source": {"id": "55-63A12E17574C48029310ED0DB4AA17D9", "name": "Completed Test Forms", "shortName": null, "type": "Other", "navigable": false}, 
 				"label": null
 			},
 			{

--- a/Examples/ProcessFlow/test/visualization01/data-bpmn01.json
+++ b/Examples/ProcessFlow/test/visualization01/data-bpmn01.json
@@ -339,7 +339,7 @@
             },
             {
                 "id": "55-Step052", 
-                "name": "", 
+                "name": "Inclusive", 
                 "type": "BPMN Inclusive Gateway", 
                 "navigable": true, 
                 "swimlanes": [{"id": "x", "actor": {"id": "55-263A0114FA2743FF99955B0FB701A78A", "name": "Store"}, "minIndex": 1}], 

--- a/Examples/ProcessFlow/webpack.common.js
+++ b/Examples/ProcessFlow/webpack.common.js
@@ -83,7 +83,7 @@ module.exports = {
         splitChunks: { //{ chunks: 'all' }
             cacheGroups: {
                 "jointjs" : {
-                    test: /[\\/]node_modules[\\/](@joint\/core*)[\\/]/,
+                    test: /[\\/]node_modules[\\/](@joint[\\/]core*)[\\/]/,
                     name: 'jointjs',
                     chunks: 'all',
                     priority: -3,

--- a/Examples/ProcessFlow/webpack.common.js
+++ b/Examples/ProcessFlow/webpack.common.js
@@ -45,7 +45,7 @@ module.exports = {
     ignoreWarnings: [
         {
             module: /jointjs-graph.js/,
-            message: /export.*\(imported as \'joint\'\) was not found in \'jointjs\'/
+            message: /export.*\(imported as \'joint\'\) was not found in '@joint\/core'/
         }
     ],
     entry: fs.readdirSync(path.join(__dirname, 'src'))
@@ -83,7 +83,7 @@ module.exports = {
         splitChunks: { //{ chunks: 'all' }
             cacheGroups: {
                 "jointjs" : {
-                    test: /[\\/]node_modules[\\/](jointjs*)[\\/]/,
+                    test: /[\\/]node_modules[\\/](@joint\/core*)[\\/]/,
                     name: 'jointjs',
                     chunks: 'all',
                     priority: -3,


### PR DESCRIPTION
Update to Process Flow to use JointJS v4.1.3
Deprecated properties refWidth and refHeight remain for elements where text label is outside the bounding box.